### PR TITLE
feat: recipe e2e 테스트코드 추가

### DIFF
--- a/e2e/레시피추가삭제.spec.ts
+++ b/e2e/레시피추가삭제.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+test("메뉴 관리자는 레시피를 등록, 수정, 삭제할 수 있다.", async ({ page }) => {
+  // 1. 메뉴 관리자는 레시피를 등록할 수 있다.
+  await page.goto("http://localhost:3000/");
+  await page.getByRole("button", { name: "레시피 조회" }).click();
+  await page.getByRole("button", { name: "추가하기" }).click();
+  await page.getByLabel("레시피 이름 입력").click();
+  await page.getByLabel("레시피 이름 입력").fill("새로운 레시피 이름");
+  await page.getByLabel("1번째 원자재 선택").first().click();
+  await page.getByText("원두").click();
+  await page.getByLabel("1번째 원자재 양 입력").click();
+  await page.getByLabel("1번째 원자재 양 입력").fill("10");
+  await page.getByRole("button", { name: "확인" }).click();
+  await expect(page.getByText("새로운 레시피 이름")).toBeVisible();
+
+  // 2. 메뉴 관리자는 레시피를 수정할 수 있다.
+  await page.getByLabel("레시피 이름 수정하기").locator("svg").click();
+  await page.getByLabel("레시피 이름 입력").click();
+  await page.getByLabel("레시피 이름 입력").fill("수정된 레시피 이름");
+  await page.getByRole("button", { name: "확인" }).click();
+
+  await expect(page.getByText("레시피를 수정하였습니다.")).toBeVisible();
+  await expect(page.getByText("새로운 레시피 이름")).not.toBeVisible();
+  await expect(page.getByText("수정된 레시피 이름")).toBeVisible();
+
+  // 3. 메뉴 관리자는 레시피를 삭제할 수 있다.
+  await page.getByLabel("수정된 레시피 이름 수정하기").locator("svg").click();
+  await page.getByRole("button", { name: "삭제" }).click();
+  await page.getByRole("button", { name: "네" }).click();
+  await expect(page.getByText("레시피를 삭제하였습니다.")).toBeVisible();
+  await expect(page.getByText("수정된 레시피 이름")).not.toBeVisible();
+});

--- a/src/modules/recipe/RecipeForm.tsx
+++ b/src/modules/recipe/RecipeForm.tsx
@@ -1,10 +1,10 @@
 import { Ingredient } from "@/domain/model/recipe/Ingredient";
 import { Recipe } from "@/domain/model/recipe/Recipe";
-import { Button, Divider, Flex, Form, Input, Select } from "antd";
-import { useForm, Controller, useFieldArray } from "react-hook-form";
-import { useQueryMaterials } from "../material/useMaterial";
-import { MinusOutlined, PlusOutlined } from "@ant-design/icons";
 import { AsyncBoundary } from "@/utils/AsyncBoundary";
+import { MinusOutlined, PlusOutlined } from "@ant-design/icons";
+import { Button, Divider, Flex, Form, Input, Select } from "antd";
+import { Controller, useFieldArray, useForm } from "react-hook-form";
+import { useQueryMaterials } from "../material/useMaterial";
 
 interface Fields {
   id?: Recipe["id"];
@@ -104,13 +104,15 @@ export function _Form({ onSubmit, defaultValues }: Props) {
               render={({ field, fieldState: { error } }) => {
                 return (
                   <Form.Item
-                    aria-label={`${index + 1}번째 원자재 양 입력`}
                     label="양"
                     required={true}
                     help={error?.message}
                     validateStatus={error != null ? "error" : undefined}
                   >
-                    <Input {...field} />
+                    <Input
+                      aria-label={`${index + 1}번째 원자재 양 입력`}
+                      {...field}
+                    />
                   </Form.Item>
                 );
               }}

--- a/src/pages/recipe-list/RecipeListPage.tsx
+++ b/src/pages/recipe-list/RecipeListPage.tsx
@@ -1,8 +1,8 @@
-import { AsyncBoundary } from "@/utils/AsyncBoundary";
 import { 라우트 } from "@/constants/route";
 import { useQueryRecipes } from "@/modules/recipe/useRecipe";
+import { AsyncBoundary } from "@/utils/AsyncBoundary";
 import { RightOutlined } from "@ant-design/icons";
-import { Button, List, Typography, Flex } from "antd";
+import { Button, Flex, List, Typography } from "antd";
 import { useRouter } from "next/router";
 
 export function RecipeListPage() {
@@ -45,6 +45,7 @@ function Page() {
         >
           <Typography.Text style={{ flex: 1 }}>{item.name}</Typography.Text>
           <RightOutlined
+            aria-label={`${item.name} 수정하기`}
             onClick={() => {
               router.push({
                 pathname: 라우트.레시피_수정,


### PR DESCRIPTION
recipe쪽 리팩토링을 위해서 recipe e2e 테스트코드를 추가합니다.


고민되는 포인트)

유즈케이스상으로는 등록, 수정, 삭제는 각각 분리되는게 맞다고 생각하는데 수정과 삭제를 하려면 등록을 해야하는 상황이여서 우선 테스트의 용이성을 위해 하나로 묶었습니다. 어떠한 유즈케이스를 테스트 하려면 다른 유즈케이스를 먼저 수행되었다는 전제가 필요할때가 있는데 (수정,삭제를 하려면 이미 등록된 데이터가 있어야 한다) 이런 경우에 어떻게 해야 중복을 줄일 수 있을지? 고민이네요~